### PR TITLE
use multiplatform shell command flag, reduce build output, add options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ whenever `:make` is run it will spawn a `dotnet build` command. The plugin is
 nice to use with [vim-dispatch's][vim-dispatch] `:Make` command which will
 compile (`dotnet build`) and show any errors in the quickfix window.
 
+## Compiler Settings
+
+There are two options to change what messages are populated into the quickfix windows.
+
+```vim
+let g:dotnet_compiler_errors_only = 1
+let g:dotnet_compiler_warnings_only = 1
+```
+These correspond to `--consoleLoggerParameters:ErrorOnly` and `--consoleLoggerParameters:WarningsOnly`.
+
 ## Test
 `vim-compiler-plugin-for-dotnet` automatically sets `b:dispatch = 'dotnet
 test'` for `.cs` files. This makes [vim-dispatch's][vim-dispatch] `:Dispatch`
@@ -23,7 +33,7 @@ nunit, or mstest).
 To see explanations of what went wrong in a specific test, the
 [vim-test][vim-test] plugin is nice. Put this in your vimrc: 
 
-```
+```vim
 let g:test#csharp#runner='dotnettest'
 let test#strategy = "vimterminal"
 ```
@@ -34,7 +44,7 @@ will be in a new split.
 ## Installation
 If you use [vim-plug][vim-plug] add this to your plugins:
 
-```
+```vim
 Plug 'tmadsen/vim-compiler-plugin-for-dotnet'
 ```
 

--- a/compiler/dotnet_build.vim
+++ b/compiler/dotnet_build.vim
@@ -9,11 +9,34 @@ if exists("current_compiler")
 endif
 let current_compiler = "dotnet_build"
 
+if !exists("g:dotnet_compiler_errors_only")
+  let g:dotnet_compiler_errors_only = v:false
+endif
+if !exists("g:dotnet_compiler_warnings_only")
+  let g:dotnet_compiler_warnings_only = v:false
+endif
+
 if exists(":CompilerSet") != 2		" older Vim always used :setlocal
   command -nargs=* CompilerSet setlocal <args>
 endif
 
-CompilerSet makeprg=dotnet\ build\ /p:GenerateFullPaths=true
+" command flag of --c is accepted by dotnet cli on all platforms
+" otherwise &shellcmdflag[0] can be used
+" clean first ensures consistent output
+" without NoSummary all warnings and errors are printed twice
+let makeprg_builder = ''
+let makeprg_builder = makeprg_builder .. 'dotnet clean --verbosity:quiet --nologo '
+let makeprg_builder = makeprg_builder .. '&& dotnet build --nologo --verbosity:quiet --consoleLoggerParameters:NoSummary --consoleLoggerParameters:GenerateFullPaths-true'
+
+if g:dotnet_compiler_errors_only == v:true
+   let makeprg_builder = makeprg_builder .. ' --consoleLoggerParameters:ErrorsOnly'
+endif
+if g:dotnet_compiler_warnings_only == v:true
+   let makeprg_builder = makeprg_builder .. ' --consoleLoggerParameters:WarningsOnly'
+endif
+
+" CompilerSet does not expand variables so execute must be used
+execute 'CompilerSet makeprg=' .. escape(makeprg_builder, ' ')
 CompilerSet errorformat=
     \%-A%.%#Microsoft%.%#,
     \%-ZBuild\ FAILED.,

--- a/compiler/dotnet_test.vim
+++ b/compiler/dotnet_test.vim
@@ -9,11 +9,37 @@ if exists("current_compiler")
 endif
 let current_compiler = "dotnet_test"
 
+if !exists("g:dotnet_compiler_errors_only")
+  let g:dotnet_compiler_errors_only = v:false
+endif
+if !exists("g:dotnet_compiler_warnings_only")
+  let g:dotnet_compiler_warnings_only = v:false
+endif
+
 if exists(":CompilerSet") != 2		" older Vim always used :setlocal
   command -nargs=* CompilerSet setlocal <args>
 endif
 
-CompilerSet makeprg=dotnet\ test\ /p:GenerateFullPaths=true
+" command flag of --c is accepted by dotnet cli on all platforms
+" otherwise &shellcmdflag[0] can be used
+" clean first ensures consistent output
+" without NoSummary all warnings and errors are printed twice
+let makeprg_builder = ''
+let makeprg_builder = makeprg_builder .. 'dotnet clean --nologo --verbosity:quiet'
+let makeprg_builder = makeprg_builder .. ' && dotnet build --nologo --verbosity:quiet --consoleLoggerParameters:NoSummary --consoleLoggerParameters:GenerateFullPaths-true'
+
+if g:dotnet_compiler_errors_only == v:true
+   let makeprg_builder = makeprg_builder .. ' --consoleLoggerParameters:ErrorsOnly'
+endif
+if g:dotnet_compiler_warnings_only == v:true
+   let makeprg_builder = makeprg_builder .. ' --consoleLoggerParameters:WarningsOnly'
+endif
+
+" separate build and test allow more fine grained control over output
+let makeprg_builder = makeprg_builder .. ' && dotnet test --verbosity:minimal --nologo --consoleLoggerParameters:ErrorsOnly'
+
+" CompilerSet does not expand variables so execute must be used
+execute 'CompilerSet makeprg=' .. escape(makeprg_builder, ' ')
 CompilerSet errorformat=
 	\%.%#=%f(%l\\\,%c):\ %tarning\ %m\ [%.%#],
 	\%.%#=%f(%l\\\,%c):\ %trror\ %m\ [%.%#],


### PR DESCRIPTION
- Switch the shell command flag from / to --, which the dotnet cli supports on all platforms (previously did not work on Linux or under Git Bash on Windows)
- Introduce verbosity flags to limit dotnet cli output to only relevant output
- Run dotnet clean first to ensure consistent generation of warnings and errors
- Add options for users to limit to only warnings or only errors